### PR TITLE
Fix #1 - Rework "required" guns

### DIFF
--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -16,16 +16,17 @@
       <label for="hideCompleted">Hide completed</label>
     </div>
 
-    <div class="checkbox" v-if="'hideNonRequired' in filters">
+    <!--<div class="checkbox" v-if="'hideNonRequired' in filters">
       <input id="hideNonRequired" type="checkbox" v-model="filters.hideNonRequired" @change="filterChange()">
       <label for="hideNonRequired">Hide non required</label>
-    </div>
+    </div>-->
 
     <div class="symbols" v-if="showSymbols">
-      <div :class="['symbol', type]">
-        <span></span>
-        <p>Required for {{ type === 'ultra' ? 'DM Ultra' : 'Dark Aether' }}</p>
-      </div>
+      <eva-icon class="info" 
+                name="question-mark-circle" 
+                fill="white" 
+                v-tippy="{ placement: 'bottom' }" 
+                :content="'You only need to completed the number of base guns there are for each category to earn the Diamond camouflage. For example, the Assault Rifles requires 5 Gold camouflages to reward the Diamond camouflage.'"></eva-icon>
     </div>
   </div>
 </template>
@@ -90,40 +91,13 @@ export default {
       margin-top: 35px;
     }
 
-    .symbol {
-      align-items: center;
-      display: flex;
+    .info {
+      cursor: pointer;
+      opacity: .5;
+      transition: $transition;
 
-      &.ultra, &.aether {
-        span {
-          $size: 10px;
-
-          background: $purple;
-          border-radius: $size;
-          display: block;
-          height: $size;
-          margin-right: 10px;
-          width: $size;
-
-          @media (max-width: $tablet) {
-            $size: 15px;
-
-            border-radius: $size;
-            height: $size;
-            width: $size;
-          }
-        }
-
-        p {
-          color: rgba(white, .35);
-          font-size: 14px;
-        }
-      }
-
-      &.aether {
-        span {
-          background: $red;
-        }
+      &:hover {
+        opacity: .75;
       }
     }
   }

--- a/src/components/Progress.vue
+++ b/src/components/Progress.vue
@@ -37,8 +37,7 @@
 
     computed: {
       progress() {
-        let { completed, total } = this.calculateProgress([...this.$store.state.weapons]);
-        return this.roundToTwoDecimals((completed / total) * 100);
+        return this.roundToTwoDecimals(this.calculateProgress([...this.$store.state.weapons]) * 100);
       }
     },
 
@@ -52,12 +51,21 @@
 
     methods: {
       calculateProgress(weapons) {
-        weapons = weapons.filter(weapon => weapon.required);
+        const categories = ['Assault Rifle', 'Launcher', 'Light Machine Gun', 'Melee', 'Pistol', 'Shotgun', 'Sniper Rifle', 'Special', 'Sub Machine Gun', 'Tactical Rifle'];
+        const progress = {};
 
-        return {
-          total: weapons.length * 7, // 7 for the number of camouflages
-          completed: weapons.reduce((a, weapon) => a + Object.values(weapon.progress[this.type]).reduce((b, progress) => b + progress, 0), 0)
-        }
+        categories.forEach(category => {
+          const categoryWeapons = weapons.filter(weapon => weapon.category === category);
+          const required = categoryWeapons.filter(weapon => !weapon.dlc).length * 7; // 7 for the number of camouflages
+          const completed = categoryWeapons.reduce((a, weapon) => a + Object.values(weapon.progress[this.type]).reduce((b, progress) => b + progress, 0), 0);
+          progress[category] = completed / required > 1 ? 1 : completed / required;
+        });
+        
+        return this.average(Object.values(progress))
+      },
+
+      average(arr) {
+        return arr.reduce((p, c) => p + c, 0) / arr.length;
       },
 
       handleCompleted() {

--- a/src/data/weapons/assaultRifles.js
+++ b/src/data/weapons/assaultRifles.js
@@ -1,12 +1,12 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
 const weapons = ['AK-47', 'FFAR 1', 'Krig 6', 'QBZ-83', 'XM4', 'Groza']
-const required = ['AK-47', 'FFAR 1', 'Krig 6', 'QBZ-83', 'XM4']
+const original = ['AK-47', 'FFAR 1', 'Krig 6', 'QBZ-83', 'XM4']
 
 export default weapons.map(weapon => ({
   category: 'Assault Rifle',
   name: weapon,
-  required: required.includes(weapon),
+  dlc: !original.includes(weapon),
   progress: {
     aether: { ...aetherProgress },
     ultra: { ...ultraProgress }

--- a/src/data/weapons/launchers.js
+++ b/src/data/weapons/launchers.js
@@ -1,12 +1,12 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
 const weapons = ['Cigma 2', 'RPG-7']
-const required = ['Cigma 2', 'RPG-7']
+const original = ['Cigma 2', 'RPG-7']
 
 export default weapons.map(weapon => ({
   category: 'Launcher',
   name: weapon,
-  required: required.includes(weapon),
+  dlc: !original.includes(weapon),
   progress: {
     aether: { ...aetherProgress },
     ultra: { ...ultraProgress }

--- a/src/data/weapons/lightMachineGuns.js
+++ b/src/data/weapons/lightMachineGuns.js
@@ -1,12 +1,12 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
 const weapons = ['Stoner 63', 'RPD', 'M60']
-const required = ['Stoner 63', 'RPD', 'M60']
+const original = ['Stoner 63', 'RPD', 'M60']
 
 export default weapons.map(weapon => ({
   category: 'Light Machine Gun',
   name: weapon,
-  required: required.includes(weapon),
+  dlc: !original.includes(weapon),
   progress: {
     aether: { ...aetherProgress },
     ultra: { ...ultraProgress }

--- a/src/data/weapons/melee.js
+++ b/src/data/weapons/melee.js
@@ -1,12 +1,12 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
 const weapons = ['Knife']
-const required = ['Knife']
+const original = ['Knife']
 
 export default weapons.map(weapon => ({
   category: 'Melee',
   name: weapon,
-  required: required.includes(weapon),
+  dlc: !original.includes(weapon),
   progress: {
     aether: { ...aetherProgress },
     ultra: { ...ultraProgress }

--- a/src/data/weapons/pistols.js
+++ b/src/data/weapons/pistols.js
@@ -1,12 +1,12 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
 const weapons = ['1911', 'Magnum', 'Diamatti']
-const required = ['1911', 'Magnum', 'Diamatti']
+const original = ['1911', 'Magnum', 'Diamatti']
 
 export default weapons.map(weapon => ({
   category: 'Pistol',
   name: weapon,
-  required: required.includes(weapon),
+  dlc: !original.includes(weapon),
   progress: {
     aether: { ...aetherProgress },
     ultra: { ...ultraProgress }

--- a/src/data/weapons/shotguns.js
+++ b/src/data/weapons/shotguns.js
@@ -1,12 +1,12 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
 const weapons = ['Hauer 77', 'Gallo SA12']
-const required = ['Hauer 77', 'Gallo SA12']
+const original = ['Hauer 77', 'Gallo SA12']
 
 export default weapons.map(weapon => ({
   category: 'Shotgun',
   name: weapon,
-  required: required.includes(weapon),
+  dlc: !original.includes(weapon),
   progress: {
     aether: { ...aetherProgress },
     ultra: { ...ultraProgress }

--- a/src/data/weapons/sniperRifles.js
+++ b/src/data/weapons/sniperRifles.js
@@ -1,12 +1,12 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
 const weapons = ['Pellington 703', 'LW3-Tundra', 'M82']
-const required = ['Pellington 703', 'LW3-Tundra', 'M82']
+const original = ['Pellington 703', 'LW3-Tundra', 'M82']
 
 export default weapons.map(weapon => ({
   category: 'Sniper Rifle',
   name: weapon,
-  required: required.includes(weapon),
+  dlc: !original.includes(weapon),
   progress: {
     aether: { ...aetherProgress },
     ultra: { ...ultraProgress }

--- a/src/data/weapons/special.js
+++ b/src/data/weapons/special.js
@@ -1,12 +1,12 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
 const weapons = ['M79']
-const required = ['M79']
+const original = ['M79']
 
 export default weapons.map(weapon => ({
   category: 'Special',
   name: weapon,
-  required: required.includes(weapon),
+  dlc: !original.includes(weapon),
   progress: {
     aether: { ...aetherProgress },
     ultra: { ...ultraProgress }

--- a/src/data/weapons/subMachineGuns.js
+++ b/src/data/weapons/subMachineGuns.js
@@ -1,12 +1,12 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
 const weapons = ['AK-74u', 'Bullfrog', 'KSP 45', 'Milano 821', 'MP5', 'MAC-10']
-const required = ['AK-74u', 'Bullfrog', 'KSP 45', 'Milano 821', 'MP5']
+const original = ['AK-74u', 'Bullfrog', 'KSP 45', 'Milano 821', 'MP5']
 
 export default weapons.map(weapon => ({
   category: 'Sub Machine Gun',
   name: weapon,
-  required: required.includes(weapon),
+  dlc: !original.includes(weapon),
   progress: {
     aether: { ...aetherProgress },
     ultra: { ...ultraProgress }

--- a/src/data/weapons/tacticalRifles.js
+++ b/src/data/weapons/tacticalRifles.js
@@ -1,12 +1,12 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
 const weapons = ['Type 63', 'M16', 'AUG', 'DMR 14']
-const required = ['Type 63', 'M16', 'AUG', 'DMR 14']
+const original = ['Type 63', 'M16', 'AUG', 'DMR 14']
 
 export default weapons.map(weapon => ({
   category: 'Tactical Rifle',
   name: weapon,
-  required: required.includes(weapon),
+  dlc: !original.includes(weapon),
   progress: {
     aether: { ...aetherProgress },
     ultra: { ...ultraProgress }


### PR DESCRIPTION
Reworked the way "required" guns are handled. The camouflage system in this game differs from Modern Warfare (2019) in that DLC weapons counts towards the Diamond camouflage progress. You only need to complete the total number of base game guns.

For example, at the time of writing the Assault Rifles consists of 5 base game rifles and 1 DLC rifle. One could complete the DLC rifle and 4 base game rifles to earn the Diamond camouflage, essentially.