### PR TITLE
Cold War Season 2

### DIFF
--- a/src/components/Progress.vue
+++ b/src/components/Progress.vue
@@ -51,7 +51,7 @@
 
     methods: {
       calculateProgress(weapons) {
-        const categories = ['Assault Rifle', 'Launcher', 'Light Machine Gun', 'Melee', 'Pistol', 'Shotgun', 'Sniper Rifle', 'Special', 'Submachine Gun', 'Tactical Rifle'];
+        const categories = ['Assault Rifles', 'Launchers', 'Light Machine Guns', 'Melee', 'Pistols', 'Shotguns', 'Sniper Rifles', 'Special', 'Submachine Guns', 'Tactical Rifles'];
         const progress = {};
 
         categories.forEach(category => {

--- a/src/data/camouflages.js
+++ b/src/data/camouflages.js
@@ -3,106 +3,106 @@ export default [
   {
     name: 'Spray',
     requirements: {
-      'Assault Rifle': { default: '300 Kills' },
-      'Launcher': { default: '50 Kills' },
-      'Light Machine Gun': { default: '300 Kills' },
+      'Assault Rifles': { default: '300 Kills' },
+      'Launchers': { default: '50 Kills' },
+      'Light Machine Guns': { default: '300 Kills' },
       'Melee': { default: '75 Kills' },
-      'Pistol': { default: '150 Kills' },
-      'Shotgun': { default: '200 Kills' },
-      'Sniper Rifle': { default: '200 Kills' },
+      'Pistols': { default: '150 Kills' },
+      'Shotguns': { default: '200 Kills' },
+      'Sniper Rifles': { default: '200 Kills' },
       'Special': { default: '50 Kills' },
-      'Submachine Gun': { default: '300 Kills' },
-      'Tactical Rifle': { default: '300 Kills' }
+      'Submachine Guns': { default: '300 Kills' },
+      'Tactical Rifles': { default: '300 Kills' }
     }
   },
   {
     name: 'Stripes',
     requirements: {
-      'Assault Rifle': { default: '100 Headshots' },
-      'Launcher': { default: '50 Streaks/Equipment' },
-      'Light Machine Gun': { default: '100 Headshots' },
+      'Assault Rifles': { default: '100 Headshots' },
+      'Launchers': { default: '50 Streaks/Equipment' },
+      'Light Machine Guns': { default: '100 Headshots' },
       'Melee': { default: '25 Backstabs' },
-      'Pistol': { default: '50 Headshots' },
-      'Shotgun': { default: '50 Headshots' },
-      'Sniper Rifle': { default: '50 Headshots' },
+      'Pistols': { default: '50 Headshots' },
+      'Shotguns': { default: '50 Headshots' },
+      'Sniper Rifles': { default: '50 Headshots' },
       'Special': { default: 'Destroy 50 killstreaks or equipment' },
-      'Submachine Gun': { default: '75 Headshots' },
-      'Tactical Rifle': { default: '100 Headshots' }
+      'Submachine Guns': { default: '75 Headshots' },
+      'Tactical Rifles': { default: '100 Headshots' }
     }
   },
   {
     name: 'Classic',
     requirements: {
-      'Assault Rifle': { default: '5 kills without dying 20 times' },
-      'Launcher': { default: '3 kills without dying 20 times' },
-      'Light Machine Gun': { default: '5 kills without dying 20 times' },
+      'Assault Rifles': { default: '5 kills without dying 20 times' },
+      'Launchers': { default: '2 kills without dying 20 times' },
+      'Light Machine Guns': { default: '5 kills without dying 20 times' },
       'Melee': { default: '25 Finish Move' },
-      'Pistol': { default: '5 kills without dying 20 times' },
-      'Shotgun': { default: '5 kills without dying 20 times' },
-      'Sniper Rifle': { default: '5 kills without dying 20 times' },
-      'Special': { default: '3 kills without dying 20 times' },
-      'Submachine Gun': { default: '5 kills without dying 20 times' },
-      'Tactical Rifle': { default: '5 kills without dying 20 times' }
+      'Pistols': { default: '5 kills without dying 20 times' },
+      'Shotguns': { default: '5 kills without dying 20 times' },
+      'Sniper Rifles': { default: '5 kills without dying 20 times' },
+      'Special': { default: '2 kills without dying 20 times' },
+      'Submachine Guns': { default: '5 kills without dying 20 times' },
+      'Tactical Rifles': { default: '5 kills without dying 20 times' }
     }
   },
   {
     name: 'Geometric',
     requirements: {
-      'Assault Rifle': { default: '50 Longshots' },
-      'Launcher': { default: 'Destroy 50 ground-based killstreaks' },
-      'Light Machine Gun': { default: '50 Longshots' },
+      'Assault Rifles': { default: '50 Longshots' },
+      'Launchers': { default: 'Destroy 50 ground-based killstreaks' },
+      'Light Machine Guns': { default: '50 Longshots' },
       'Melee': { default: '50 kills while injured' },
-      'Pistol': { default: '25 Longshots' },
-      'Shotgun': { default: '50 Longshots' },
-      'Sniper Rifle': { default: '50 Longshots' },
+      'Pistols': { default: '25 Longshots' },
+      'Shotguns': { default: '50 Longshots' },
+      'Sniper Rifles': { default: '50 Longshots' },
       'Special': { default: 'Destroy 50 ground-based killstreaks' },
-      'Submachine Gun': { default: '50 Longshots' },
-      'Tactical Rifle': { default: '50 Longshots' }
+      'Submachine Guns': { default: '50 Longshots' },
+      'Tactical Rifles': { default: '50 Longshots' }
     }
   },
   {
     name: 'Flora',
     requirements: {
-      'Assault Rifle': { default: '75 Stunned/Detected' },
-      'Launcher': { default: 'Destroy 50 air-based killstreaks' },
-      'Light Machine Gun': { default: '75 Stunned/Detected' },
+      'Assault Rifles': { default: '75 Stunned/Detected' },
+      'Launchers': { default: 'Destroy 50 air-based killstreaks' },
+      'Light Machine Guns': { default: '75 Stunned/Detected' },
       'Melee': { default: '50 kills while sliding' },
-      'Pistol': { default: '25 Stunned/Detected' },
-      'Shotgun': { default: '75 Stunned/Detected' },
-      'Sniper Rifle': { default: '50 Holding Breath' },
+      'Pistols': { default: '25 Stunned/Detected' },
+      'Shotguns': { default: '75 Stunned/Detected' },
+      'Sniper Rifles': { default: '50 Holding Breath' },
       'Special': { default: 'Destroy 50 air-based killstreaks' },
-      'Submachine Gun': { default: '75 Stunned/Detected' },
-      'Tactical Rifle': { default: '75 Stunned/Detected' }
+      'Submachine Guns': { default: '75 Stunned/Detected' },
+      'Tactical Rifles': { default: '75 Stunned/Detected' }
     }
   },
   {
     name: 'Science',
     requirements: {
-      'Assault Rifle': { default: '50 Anti-Cover' },
-      'Launcher': { default: '10 3-streaks' },
-      'Light Machine Gun': { default: '50 Anti-Cover' },
+      'Assault Rifles': { default: '50 Anti-Cover' },
+      'Launchers': { default: '10 3-streaks' },
+      'Light Machine Guns': { default: '50 Anti-Cover' },
       'Melee': { default: '50 Stunned/Detected' },
-      'Pistol': { default: '25 Anti-Cover' },
-      'Shotgun': { default: '75 Point-Blank' },
-      'Sniper Rifle': { default: '50 One Shot Kills' },
+      'Pistols': { default: '25 Anti-Cover' },
+      'Shotguns': { default: '75 Point-Blank' },
+      'Sniper Rifles': { default: '50 One Shot Kills' },
       'Special': { default: '10 3-streaks' },
-      'Submachine Gun': { default: '75 Point-Blank' },
-      'Tactical Rifle': { default: '50 Anti-Cover' }
+      'Submachine Guns': { default: '75 Point-Blank' },
+      'Tactical Rifles': { default: '50 Anti-Cover' }
     }
   },
   {
     name: 'Psychadelic',
     requirements: {
-      'Assault Rifle': { default: '25 Double Kills' },
-      'Launcher': { default: '25 Double Kills' },
-      'Light Machine Gun': { default: '25 Double Kills' },
+      'Assault Rifles': { default: '25 Double Kills' },
+      'Launchers': { default: '25 Double Kills' },
+      'Light Machine Guns': { default: '25 Double Kills' },
       'Melee': { default: '25 Double Kills' },
-      'Pistol': { default: '25 Double Kills' },
-      'Shotgun': { default: '25 Double Kills' },
-      'Sniper Rifle': { default: '25 Double Kills' },
+      'Pistols': { default: '25 Double Kills' },
+      'Shotguns': { default: '25 Double Kills' },
+      'Sniper Rifles': { default: '25 Double Kills' },
       'Special': { default: '25 Double Kills' },
-      'Submachine Gun': { default: '25 Double Kills' },
-      'Tactical Rifle': { default: '25 Double Kills' }
+      'Submachine Guns': { default: '25 Double Kills' },
+      'Tactical Rifles': { default: '25 Double Kills' }
     }
   },
 
@@ -110,106 +110,106 @@ export default [
   {
     name: 'Grunge',
     requirements: {
-      'Assault Rifle': { default: '2500 Kills' },
-      'Launcher': { default: '1500 Kills' },
-      'Light Machine Gun': { default: '2500 Kills' },
+      'Assault Rifles': { default: '2500 Kills' },
+      'Launchers': { default: '1500 Kills' },
+      'Light Machine Guns': { default: '2500 Kills' },
       'Melee': { default: '750 Kills' },
-      'Pistol': { default: '2500 Kills' },
-      'Shotgun': { default: '2500 Kills' },
-      'Sniper Rifle': { default: '2500 Kills' },
+      'Pistols': { default: '2500 Kills' },
+      'Shotguns': { default: '2500 Kills' },
+      'Sniper Rifles': { default: '2500 Kills' },
       'Special': { default: '1500 Kills' },
-      'Submachine Gun': { default: '2500 Kills' },
-      'Tactical Rifle': { default: '2500 Kills' }
+      'Submachine Guns': { default: '2500 Kills' },
+      'Tactical Rifles': { default: '2500 Kills' }
     }
   },
   {
     name: 'Liquid',
     requirements: {
-      'Assault Rifle': { default: '2500 critical hit kills' },
-      'Launcher': { default: 'Kill 2 or more enemies rapidly 50 times' },
-      'Light Machine Gun': { default: '2500 critical hit kills' },
+      'Assault Rifles': { default: '2500 critical hit kills' },
+      'Launchers': { default: 'Kill 2 or more enemies rapidly 50 times' },
+      'Light Machine Guns': { default: '2500 critical hit kills' },
       'Melee': { default: '50 kills against enemies who are disoriented by a stun grenade, monkey bomb or decoy' },
-      'Pistol': { default: '2500 critical hit kills' },
-      'Shotgun': { default: '2500 critical hit kills' },
-      'Sniper Rifle': { default: '2500 critical hit kills' },
+      'Pistols': { default: '2500 critical hit kills' },
+      'Shotguns': { default: '2500 critical hit kills' },
+      'Sniper Rifles': { default: '2500 critical hit kills' },
       'Special': { default: 'Kill 2 or more enemies rapidly 50 times' },
-      'Submachine Gun': { default: '2500 critical hit kills' },
-      'Tactical Rifle': { default: '2500 critical hit kills' }
+      'Submachine Guns': { default: '2500 critical hit kills' },
+      'Tactical Rifles': { default: '2500 critical hit kills' }
     }
   },
   {
     name: 'Brushstroke',
     requirements: {
-      'Assault Rifle': { default: '2500 kills while the weapon is pack-a-punched' },
-      'Launcher': { default: 'Kill 5 or more enemies with a single rocket' },
-      'Light Machine Gun': { default: '2500 kills while the weapon is pack-a-punched' },
+      'Assault Rifles': { default: '2500 kills while the weapon is pack-a-punched' },
+      'Launchers': { default: 'Kill 5 or more enemies with a single rocket' },
+      'Light Machine Guns': { default: '2500 kills while the weapon is pack-a-punched' },
       'Melee': { default: '750 kills while the weapon is pack-a-punched' },
-      'Pistol': { default: '2500 kills while the weapon is pack-a-punched' },
-      'Shotgun': { default: '2500 kills while the weapon is pack-a-punched' },
-      'Sniper Rifle': { default: '2500 kills while the weapon is pack-a-punched' },
+      'Pistols': { default: '2500 kills while the weapon is pack-a-punched' },
+      'Shotguns': { default: '2500 kills while the weapon is pack-a-punched' },
+      'Sniper Rifles': { default: '2500 kills while the weapon is pack-a-punched' },
       'Special': { default: 'Kill 5 or more enemies with a single rocket' },
-      'Submachine Gun': { default: '2500 kills while the weapon is pack-a-punched' },
-      'Tactical Rifle': { default: '2500 kills while the weapon is pack-a-punched' }
+      'Submachine Guns': { default: '2500 kills while the weapon is pack-a-punched' },
+      'Tactical Rifles': { default: '2500 kills while the weapon is pack-a-punched' }
     }
   },
   {
     name: 'Vintage',
     requirements: {
-      'Assault Rifle': { default: 'Get 15 Elite eliminations' },
-      'Launcher': { default: '2500 kills while the weapon is pack-a-punched' },
-      'Light Machine Gun': { default: 'Get 15 Elite eliminations' },
+      'Assault Rifles': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' },
+      'Launchers': { default: '2500 kills while the weapon is pack-a-punched' },
+      'Light Machine Guns': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' },
       'Melee': { default: 'Get 15 kills with the knife against enemies who are affected by Frost Blast or Ring of Fire or while you have Aether Shroud active in Zombies' },
-      'Pistol': { default: 'Get 15 Elite eliminations' },
-      'Shotgun': { default: 'Get 15 Elite eliminations' },
-      'Sniper Rifle': { default: 'Get 15 Elite eliminations' },
+      'Pistols': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' },
+      'Shotguns': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' },
+      'Sniper Rifles': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' },
       'Special': { default: '2500 kills while the weapon is pack-a-punched' },
-      'Submachine Gun': { default: 'Get 15 Elite eliminations' },
-      'Tactical Rifle': { default: 'Get 15 Elite eliminations' }
+      'Submachine Guns': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' },
+      'Tactical Rifles': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' }
     }
   },
   {
     name: 'Fauna',
     requirements: {
-      'Assault Rifle': { default: 'Get 10 kills rapidly 10 times' },
-      'Launcher': { default: 'Get 10 elite eliminations' },
-      'Light Machine Gun': { default: 'Get 10 kills rapidly 10 times' },
-      'Melee': { default: '10 Elite Eliminations with the knife in Zombies' },
-      'Pistol': { default: 'Get 10 kills rapidly 10 times' },
-      'Shotgun': { default: 'Get 10 kills rapidly 10 times' },
-      'Sniper Rifle': { default: 'Get 10 kills rapidly 10 times' },
-      'Special': { default: 'Get 10 elite eliminations' },
-      'Submachine Gun': { default: 'Get 10 kills rapidly 10 times' },
-      'Tactical Rifle': { default: 'Get 10 kills rapidly 10 times' }
+      'Assault Rifles': { default: 'Get 10 kills rapidly 10 times' },
+      'Launchers': { default: 'Get 10 Special or Elite eliminations (Bosses count as 3 eliminations)' },
+      'Light Machine Guns': { default: 'Get 10 kills rapidly 10 times' },
+      'Melee': { default: 'Get 10 Special or Elite eliminations (Bosses count as 3 eliminations)' },
+      'Pistols': { default: 'Get 10 kills rapidly 10 times' },
+      'Shotguns': { default: 'Get 10 kills rapidly 10 times' },
+      'Sniper Rifles': { default: 'Get 10 kills rapidly 10 times' },
+      'Special': { default: 'Get 10 Special or Elite eliminations (Bosses count as 3 eliminations)' },
+      'Submachine Guns': { default: 'Get 10 kills rapidly 10 times' },
+      'Tactical Rifles': { default: 'Get 10 kills rapidly 10 times' }
     }
   },
   {
     name: 'Topography',
     requirements: {
-      'Assault Rifle': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
-      'Launcher': { default: 'Get 10 kills rapidly 10 times' },
-      'Light Machine Gun': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
+      'Assault Rifles': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
+      'Launchers': { default: 'Get 10 kills rapidly 10 times' },
+      'Light Machine Guns': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
       'Melee': { default: '10 kills rapidly 10 times' },
-      'Pistol': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
-      'Shotgun': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
-      'Sniper Rifle': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
+      'Pistols': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
+      'Shotguns': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
+      'Sniper Rifles': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
       'Special': { default: 'Get 10 kills rapidly 10 times' },
-      'Submachine Gun': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
-      'Tactical Rifle': { default: 'Get 3 or more critical hit kills rapidly 25 times' }
+      'Submachine Guns': { default: 'Get 3 or more critical hit kills rapidly 25 times' },
+      'Tactical Rifles': { default: 'Get 3 or more critical hit kills rapidly 25 times' }
     }
   },
   {
     name: 'Infection',
     requirements: {
-      'Assault Rifle': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
-      'Launcher': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
-      'Light Machine Gun': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
+      'Assault Rifles': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
+      'Launchers': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
+      'Light Machine Guns': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
       'Melee': { default: 'Get 20 or more consecutive kills with the knife without getting hit 10 times in Zombies' },
-      'Pistol': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
-      'Shotgun': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
-      'Sniper Rifle': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
+      'Pistols': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
+      'Shotguns': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
+      'Sniper Rifles': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
       'Special': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
-      'Submachine Gun': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
-      'Tactical Rifle': { default: 'Get 20 or more consecutive kills without getting hit 10 times' }
+      'Submachine Guns': { default: 'Get 20 or more consecutive kills without getting hit 10 times' },
+      'Tactical Rifles': { default: 'Get 20 or more consecutive kills without getting hit 10 times' }
     }
   }
 ]

--- a/src/data/weapons.js
+++ b/src/data/weapons.js
@@ -1,24 +1,23 @@
 import assaultRifles from './weapons/assaultRifles'
 import subMachineGuns from './weapons/subMachineGuns'
-import shotguns from './weapons/shotguns'
-import lightMachineGuns from './weapons/lightMachineGuns'
 import tacticalRifles from './weapons/tacticalRifles'
+import lightMachineGuns from './weapons/lightMachineGuns'
 import sniperRifles from './weapons/sniperRifles'
+import pistols from './weapons/pistols'
+import shotguns from './weapons/shotguns'
+import launchers from './weapons/launchers'
 import melee from './weapons/melee'
 import special from './weapons/special'
-import pistols from './weapons/pistols'
-import launchers from './weapons/launchers'
 
 export default [
   ...assaultRifles,
   ...subMachineGuns,
-  ...shotguns,
-  ...lightMachineGuns,
   ...tacticalRifles,
+  ...lightMachineGuns,
   ...sniperRifles,
-  ...melee,
-  ...special,
   ...pistols,
-  ...launchers
+  ...shotguns,
+  ...launchers,
+  ...melee,
+  ...special
 ]
-

--- a/src/data/weapons/assaultRifles.js
+++ b/src/data/weapons/assaultRifles.js
@@ -1,10 +1,10 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
-const weapons = ['AK-47', 'FFAR 1', 'Krig 6', 'QBZ-83', 'XM4', 'Groza']
-const original = ['AK-47', 'FFAR 1', 'Krig 6', 'QBZ-83', 'XM4']
+const weapons = ['XM4', 'AK-47', 'Krig 6', 'QBZ-83', 'FFAR 1', 'Groza', 'FARA 83']
+const original = ['XM4', 'AK-47', 'Krig 6', 'QBZ-83', 'FFAR 1',]
 
 export default weapons.map(weapon => ({
-  category: 'Assault Rifle',
+  category: 'Assault Rifles',
   name: weapon,
   dlc: !original.includes(weapon),
   progress: {

--- a/src/data/weapons/launchers.js
+++ b/src/data/weapons/launchers.js
@@ -4,7 +4,7 @@ const weapons = ['Cigma 2', 'RPG-7']
 const original = ['Cigma 2', 'RPG-7']
 
 export default weapons.map(weapon => ({
-  category: 'Launcher',
+  category: 'Launchers',
   name: weapon,
   dlc: !original.includes(weapon),
   progress: {

--- a/src/data/weapons/lightMachineGuns.js
+++ b/src/data/weapons/lightMachineGuns.js
@@ -4,7 +4,7 @@ const weapons = ['Stoner 63', 'RPD', 'M60']
 const original = ['Stoner 63', 'RPD', 'M60']
 
 export default weapons.map(weapon => ({
-  category: 'Light Machine Gun',
+  category: 'Light Machine Guns',
   name: weapon,
   dlc: !original.includes(weapon),
   progress: {

--- a/src/data/weapons/pistols.js
+++ b/src/data/weapons/pistols.js
@@ -4,7 +4,7 @@ const weapons = ['1911', 'Magnum', 'Diamatti']
 const original = ['1911', 'Magnum', 'Diamatti']
 
 export default weapons.map(weapon => ({
-  category: 'Pistol',
+  category: 'Pistols',
   name: weapon,
   dlc: !original.includes(weapon),
   progress: {

--- a/src/data/weapons/shotguns.js
+++ b/src/data/weapons/shotguns.js
@@ -4,7 +4,7 @@ const weapons = ['Hauer 77', 'Gallo SA12', 'Streetsweeper']
 const original = ['Hauer 77', 'Gallo SA12']
 
 export default weapons.map(weapon => ({
-  category: 'Shotgun',
+  category: 'Shotguns',
   name: weapon,
   dlc: !original.includes(weapon),
   progress: {

--- a/src/data/weapons/sniperRifles.js
+++ b/src/data/weapons/sniperRifles.js
@@ -4,7 +4,7 @@ const weapons = ['Pellington 703', 'LW3-Tundra', 'M82']
 const original = ['Pellington 703', 'LW3-Tundra', 'M82']
 
 export default weapons.map(weapon => ({
-  category: 'Sniper Rifle',
+  category: 'Sniper Rifles',
   name: weapon,
   dlc: !original.includes(weapon),
   progress: {

--- a/src/data/weapons/subMachineGuns.js
+++ b/src/data/weapons/subMachineGuns.js
@@ -1,10 +1,10 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
-const weapons = ['AK-74u', 'Bullfrog', 'KSP 45', 'Milano 821', 'MP5', 'MAC-10']
-const original = ['AK-74u', 'Bullfrog', 'KSP 45', 'Milano 821', 'MP5']
+const weapons = ['MP5', 'Milano 821', 'AK-74u', 'KSP 45', 'Bullfrog', 'MAC-10', 'LC10']
+const original = ['MP5', 'Milano 821', 'AK-74u', 'KSP 45', 'Bullfrog']
 
 export default weapons.map(weapon => ({
-  category: 'Submachine Gun',
+  category: 'Submachine Guns',
   name: weapon,
   dlc: !original.includes(weapon),
   progress: {

--- a/src/data/weapons/tacticalRifles.js
+++ b/src/data/weapons/tacticalRifles.js
@@ -4,7 +4,7 @@ const weapons = ['Type 63', 'M16', 'AUG', 'DMR 14']
 const original = ['Type 63', 'M16', 'AUG', 'DMR 14']
 
 export default weapons.map(weapon => ({
-  category: 'Tactical Rifle',
+  category: 'Tactical Rifles',
   name: weapon,
   dlc: !original.includes(weapon),
   progress: {


### PR DESCRIPTION
**Changelog**

**- Added Season 2 Weapons** (Releasing February 25th)
- Assault Rifles: FARA 83
- Submachine Guns: LC10

**- Further organized weapon categories to reflect Cold War.**

**- Changed weapon category names to reflect Cold War. (Added "s" to end of weapon category name)**

**- Fixed weapon order of weapon categories "Assault Rifles" and "Submachine Guns"**
- Assault Rifles: _AK-47>FFAR 1>Krig 6>QBZ-83>XM4>Groza_ >> _XM4>AK-47>Krig 6> QBZ-83>FFAR 1>Groza_
- Submachine Guns: _AK-74u>Bullfrog>KSP 45>Milano 821>MP5>MAC-10_ >> _MP5>Milano 821>AK-74u>KSP 45>Bullfrog>MAC-10_

**- Updated Launchers DM Ultra "Classic" weapon camo category challenges to reflect Cold War changes.**
- Classic: _3 kills without dying 20 times_ >> _2 kills without dying 20 times_

**- Updated certain Dark Aether "Vintage" and "Fauna" weapon camo category challenges to reflect Cold War changes.**
- Vintage: _Get 15 Elite eliminations_ >> _Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)_
- Fauna: _Get 10 Elite eliminations_ >> _Get 10 Special or Elite eliminations (Bosses count as 3 eliminations)_