### PR TITLE
Cold War Season 3 Release

### DIFF
--- a/src/data/weapons/sniperRifles.js
+++ b/src/data/weapons/sniperRifles.js
@@ -1,6 +1,6 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
-const weapons = ['Pellington 703', 'LW3-Tundra', 'M82', 'ZRG 20mm']
+const weapons = ['Pellington 703', 'LW3-Tundra', 'M82', 'ZRG 20mm', 'Swiss K31']
 const original = ['Pellington 703', 'LW3-Tundra', 'M82']
 
 export default weapons.map(weapon => ({

--- a/src/data/weapons/subMachineGuns.js
+++ b/src/data/weapons/subMachineGuns.js
@@ -1,6 +1,6 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
-const weapons = ['MP5', 'Milano 821', 'AK-74u', 'KSP 45', 'Bullfrog', 'MAC-10', 'LC10']
+const weapons = ['MP5', 'Milano 821', 'AK-74u', 'KSP 45', 'Bullfrog', 'MAC-10', 'LC10', 'PPSh-41']
 const original = ['MP5', 'Milano 821', 'AK-74u', 'KSP 45', 'Bullfrog']
 
 export default weapons.map(weapon => ({

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -72,7 +72,7 @@ export default {
         },
         {
           name: 'Reset all progress',
-          description: 'Reset your current camouflage, reticle & Master Challenges progress.',
+          description: 'Reset all your current camouflage progress (DM Ultra & Dark Aether).',
           warning: 'This action is irreversible.',
           action: 'resetAll',
           button: 'Reset progress'


### PR DESCRIPTION
**Changelog**

**- Added Season 3 Weapons** (Releasing April 22)
- Submachine Guns: PPSh-41
- Sniper Rifles: Swiss K31

**- Updated Settings page to reflect features that are currently on the website**
- Reset all progress: _Reset your current camouflage, reticle & Master Challenges progress._ >> _Reset all your current camouflage progress (DM Ultra & Dark Aether)._