### PR TITLE
Cold War Season 3 Release - Addition 1

### DIFF
--- a/src/data/weapons/melee.js
+++ b/src/data/weapons/melee.js
@@ -1,6 +1,6 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
-const weapons = ['Knife', 'Sledgehammer', 'Wakizashi', 'E-Tool', 'Machete']
+const weapons = ['Knife', 'Sledgehammer', 'Wakizashi', 'E-Tool', 'Machete', 'Ballistic Knife']
 const original = ['Knife']
 
 export default weapons.map(weapon => ({


### PR DESCRIPTION
_**Note: Was watching a video about Season 3 and they mention the Ballistic Knife melee weapon was a launch weapon, guess I read the blog post too fast, anyways I've added it now.**_ 

**_Note 2: Also, do I have to make a new pull request just to fix 1 thing or is there a way to update the old pull request with a fix without making a new pull request?_**

**Changelog**

**- Added Season 3 Weapons** (Releasing April 22)
- Submachine Guns: PPSh-41
- Sniper Rifles: Swiss K31
- Melee: Ballistic Knife (**_Fix for #19_**)

**- Updated Settings page to reflect features that are currently on the website**
- Reset all progress: _Reset your current camouflage, reticle & Master Challenges progress._ >> _Reset all your current camouflage progress (DM Ultra & Dark Aether)._