### PR TITLE
Cold War Season 3 - Added CARV.2 Tactical Rifle + Partial fix for Ballistic Knife camo challenges

### DIFF
--- a/src/data/camouflages.js
+++ b/src/data/camouflages.js
@@ -175,7 +175,8 @@ export default [
       'Sniper Rifles': { default: '2500 kills while the weapon is pack-a-punched' },
       'Special': { 
         default: 'Kill 5 or more enemies with a single rocket',
-        'R1 Shadowhunter': 'Kill 3 or more enemies with a single shot 50 times'
+        'R1 Shadowhunter': 'Kill 3 or more enemies with a single shot 50 times',
+        'Ballistic Knife': '[num] kills while the weapon is pack-a-punched'
       },
       'Submachine Guns': { default: '2500 kills while the weapon is pack-a-punched' },
       'Tactical Rifles': { default: '2500 kills while the weapon is pack-a-punched' }
@@ -193,7 +194,8 @@ export default [
       'Sniper Rifles': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' },
       'Special': { 
         default: '2500 kills while the weapon is pack-a-punched',
-        'R1 Shadowhunter': '1500 kills while the weapon is pack-a-punched'
+        'R1 Shadowhunter': '1500 kills while the weapon is pack-a-punched',
+        'Ballistic Knife': 'Get [num] kills with the Ballistic Knife against enemies who are affected by Frost Blast or Ring of Fire or while you have Aether Shroud active in Zombies'
       },
       'Submachine Guns': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' },
       'Tactical Rifles': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' }

--- a/src/data/camouflages.js
+++ b/src/data/camouflages.js
@@ -176,7 +176,7 @@ export default [
       'Special': { 
         default: 'Kill 5 or more enemies with a single rocket',
         'R1 Shadowhunter': 'Kill 3 or more enemies with a single shot 50 times',
-        'Ballistic Knife': '[num] kills while the weapon is pack-a-punched'
+        'Ballistic Knife': 'Kills while the weapon is pack-a-punched'
       },
       'Submachine Guns': { default: '2500 kills while the weapon is pack-a-punched' },
       'Tactical Rifles': { default: '2500 kills while the weapon is pack-a-punched' }
@@ -195,7 +195,7 @@ export default [
       'Special': { 
         default: '2500 kills while the weapon is pack-a-punched',
         'R1 Shadowhunter': '1500 kills while the weapon is pack-a-punched',
-        'Ballistic Knife': 'Get [num] kills with the Ballistic Knife against enemies who are affected by Frost Blast or Ring of Fire or while you have Aether Shroud active in Zombies'
+        'Ballistic Knife': 'Get kills with the Ballistic Knife against enemies who are affected by Frost Blast or Ring of Fire or while you have Aether Shroud active in Zombies'
       },
       'Submachine Guns': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' },
       'Tactical Rifles': { default: 'Get 15 Special or Elite eliminations (Bosses count as 3 eliminations)' }

--- a/src/data/weapons/tacticalRifles.js
+++ b/src/data/weapons/tacticalRifles.js
@@ -1,6 +1,6 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
-const weapons = ['Type 63', 'M16', 'AUG', 'DMR 14']
+const weapons = ['Type 63', 'M16', 'AUG', 'DMR 14', 'CARV.2']
 const original = ['Type 63', 'M16', 'AUG', 'DMR 14']
 
 export default weapons.map(weapon => ({


### PR DESCRIPTION
**Note: It's been 2 weeks and Treyarch still hasn't fixed the Ballistic Knife, I'm just going to take it out of draft mode since the CARV.2 Tactical Rifle is out.**

### May 6th
**Changelog**

**- Added Season 3 Weapons** 
- Tactical Rifles: CARV.2

### April 22nd

Ballistic Knife is a Special weapon and not a Melee weapon. Also added the camo challenges for the Ballistic Knife

**Changelog**

**- Added Season 3 Weapons** 
- Submachine Guns: PPSh-41
- Sniper Rifles: Swiss K31
- Special: Ballistic Knife

**- Updated camo challenges for the Ballistic Knife**

**Ballistic Knife Challenges**

**DM Ultra**
- Spray: 100 Kills
- Stripes: Get both a melee kill and projectile kill in the same life 25 times
- Classic: 3 kills without dying 20 times
- Geometric: 25 Backstabber medals
- Flora: 50 kills while sliding
- Science: 50 kills against enemies who are disoriented by a smoke grenade, flash or stun grenades
- Psychadelic: 25 Double Kills

**Dark Aether**
- Grunge: 1500 Kills
- Liquid: 50 kills against enemies who are disoriented by a stun grenade, monkey bomb or decoy
- Brushstroke: [num] kills while the weapon is pack-a-punched (**_Fix for #21_**)
- Vintage: Get [num] kills with the Ballistic Knife against enemies who are affected by Frost Blast or Ring of Fire or while you have Aether Shroud active in Zombies (**_Fix for #21_**)
- Fauna: Get 10 Special or Elite eliminations (Bosses count as 3 eliminations)
- Topography: Get 2 kills rapidly 10 times
- Infection: Get 20 or more consecutive kills without getting hit 10 times

**- Updated Settings page to reflect features that are currently on the website**
- Reset all progress: _Reset your current camouflage, reticle & Master Challenges progress._ >> _Reset all your current camouflage progress (DM Ultra & Dark Aether)._