### PR TITLE
Sol3uk/include camo name suggestion

### DIFF
--- a/src/components/Weapons.vue
+++ b/src/components/Weapons.vue
@@ -38,6 +38,7 @@
 
 <script>
   import { convertToKebabCase } from '@/utils/utils'
+  import { camoStrings } from '@/data/defaults'
 
   export default {
     props: ['weapons', 'mode'],
@@ -57,7 +58,7 @@
 
       camoTooltip(category, camo, weapon) {
         let requirement = this.$store.state.camouflages.find(c => c.name === camo).requirements[category];
-        return `${ camo } - ${ requirement[weapon.name] ? requirement[weapon.name] : requirement.default }`;
+        return `${ camoStrings[camo] } - ${ requirement[weapon.name] ? requirement[weapon.name] : requirement.default }`;
       },
 
       categoryProgress(category) {

--- a/src/data/defaults.js
+++ b/src/data/defaults.js
@@ -1,3 +1,21 @@
+const camoStrings = {
+  'Spray': 'Spray: Prosper',
+  'Stripes': 'Stripes: Bengal',
+  'Classic': 'Classic: Ransom',
+  'Geometric': 'Geometric: Bloodline',
+  'Flora': 'Flora: Cherry Blossom',
+  'Science': 'Science: Policia',
+  'Psychadelic': 'Psychadelic: Bliss',
+
+  'Grunge': 'Grunge: Rotten',
+  'Liquid': 'Liquid: Banished',
+  'Brushstroke': 'Brushstroke: Chemical',
+  'Vintage': 'Vintage: Maniac',
+  'Fauna': 'Fauna: Rising Tiger',
+  'Topography': 'Topography: Sunder',
+  'Infection': 'Infection: Conviction',
+}
+
 // Default progress for DM Ultra
 const ultraProgress = {
   'Spray': false,
@@ -35,4 +53,4 @@ const defaultFilters = {
   }
 }
 
-export { ultraProgress, aetherProgress, defaultFilters }
+export { ultraProgress, aetherProgress, defaultFilters, camoStrings }


### PR DESCRIPTION
I have added the name of the camo shown in the images to the tooltip.
The reason for this is that in the game, only the camo name is shown, so when I'm playing a long game of Zombies/MP I will be waiting for the name of the camo to pop up, not the category name 😅 

![image](https://user-images.githubusercontent.com/26093813/137776750-e321b6aa-1016-41ec-8e55-0ffed35c6100.png)

Hopefully this is a small enough change that it's not an issue to merge, and it can help anyone else in the same scenario as me, who needs to know the camo names!