### PR TITLE
Cold War Year 2 - Vargo 52 Assault Rifle

### DIFF
--- a/src/data/weapons/assaultRifles.js
+++ b/src/data/weapons/assaultRifles.js
@@ -1,6 +1,6 @@
 import { ultraProgress, aetherProgress } from '../defaults'
 
-const weapons = ['XM4', 'AK-47', 'Krig 6', 'QBZ-83', 'FFAR 1', 'Groza', 'FARA 83', 'C58', 'EM2', 'Grav']
+const weapons = ['XM4', 'AK-47', 'Krig 6', 'QBZ-83', 'FFAR 1', 'Groza', 'FARA 83', 'C58', 'EM2', 'Grav', 'Vargo 52']
 const original = ['XM4', 'AK-47', 'Krig 6', 'QBZ-83', 'FFAR 1',]
 
 export default weapons.map(weapon => ({


### PR DESCRIPTION
### **_Update releases on March 4th, 2022._**

**Changelog**

**- Added New Weapon**
- Assault Rifle: Vargo 52


_Sorry for not updating the Vanguard tracker after asking for it, Cold War has burned me out of COD lol. I'll try to keep up with Vanguard updates even though I don't have to but I want to. 👍_ 